### PR TITLE
Fix: improve login error responses (#15)

### DIFF
--- a/backend/src/main/java/com/jamesmcdonald/backend/constants/ErrorMessages.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/constants/ErrorMessages.java
@@ -2,6 +2,7 @@ package com.jamesmcdonald.backend.constants;
 
 public class ErrorMessages {
     public static final String ACCOUNT_NOT_FOUND = "Account not found";
-    public static final String INVALID_CARD_OR_PIN = "Invalid card number or PIN";
+    public static final String INVALID_CARD_OR_PIN_OR_PASSWORD = "Invalid card number, PIN or " +
+            "password";
     public static final String EMAIL_ALREADY_IN_USE = "Email already in use.";
 }

--- a/backend/src/main/java/com/jamesmcdonald/backend/login/LoginController.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/login/LoginController.java
@@ -4,6 +4,7 @@ import com.jamesmcdonald.backend.account.Account;
 import com.jamesmcdonald.backend.account.AccountRepository;
 import com.jamesmcdonald.backend.constants.ErrorMessages;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,19 +31,21 @@ public class LoginController {
 
         if (account.isPresent()) {
             Account foundAccount = account.get();
-            AccountResponse accountResponse =  new AccountResponse(
+            return ResponseEntity.ok(new AccountResponse(
                     foundAccount.getId(),
                     foundAccount.getCardNumber(),
                     foundAccount.getBalance(),
                     foundAccount.getName(),
                     foundAccount.getEmail(),
                     foundAccount.getPhone()
-            );
-            return ResponseEntity.ok(accountResponse);
-        } else {
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(ErrorMessages.INVALID_CARD_OR_PIN);
+            ));
         }
+
+        ProblemDetail problemDetail = ProblemDetail.forStatus((HttpStatus.UNAUTHORIZED));
+        problemDetail.setTitle("Invalid credentials");
+        problemDetail.setDetail(ErrorMessages.INVALID_CARD_OR_PIN_OR_PASSWORD);
+        problemDetail.setProperty("code", "AUTH_INVALID_CREDENTIALS");
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
     }
 }


### PR DESCRIPTION
- Return structured JSON error with code, title, detail 
- Use application/problem+json for invalid credentials 
- Add parameterised test for invalid card, PIN, or password

Closes #15