### PR TITLE
feat(validation): add global handler and enforce login payload constaints. Tests included.

### DIFF
--- a/backend/src/main/java/com/jamesmcdonald/backend/exception/GlobalValidationAdvice.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/exception/GlobalValidationAdvice.java
@@ -1,0 +1,23 @@
+package com.jamesmcdonald.backend.exception;
+
+
+import org.springframework.http.*;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalValidationAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ProblemDetail> handleValidation(MethodArgumentNotValidException ex) {
+        ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problem.setTitle("Invalid request content");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(problem);
+    }
+}

--- a/backend/src/main/java/com/jamesmcdonald/backend/login/LoginController.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/login/LoginController.java
@@ -3,6 +3,7 @@ package com.jamesmcdonald.backend.login;
 import com.jamesmcdonald.backend.account.Account;
 import com.jamesmcdonald.backend.account.AccountRepository;
 import com.jamesmcdonald.backend.constants.ErrorMessages;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class LoginController {
     }
 
     @PostMapping
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
         return this.loginService.authenticate(
                 request.cardNumber(),
                 request.pin(),

--- a/backend/src/main/java/com/jamesmcdonald/backend/login/LoginRequest.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/login/LoginRequest.java
@@ -1,7 +1,17 @@
 package com.jamesmcdonald.backend.login;
 
+import jakarta.validation.constraints.*;
+
 public record LoginRequest(
+        @NotBlank
+        @Pattern(regexp = "\\d{16}", message = "Card number must be 16 digits")
         String cardNumber,
+
+        @NotBlank
+        @Pattern(regexp = "\\d{4}", message = "PIN must be 4 digits")
         String pin,
+
+        @NotBlank
+        @Size(min = 4, message = "Password must be at least 4 characters")
         String password
-) { }
+) {}


### PR DESCRIPTION
- Add GlobalValidationAdvice to return 400 ProblemDetail for bean validation failures
- Annotate LoginRequest with @Pattern/@NotBlank constraints
- Mark controller argument as @Valid
- Update MVC tests to cover 400 on invalid payloads

Closes #24