### PR TITLE
feat(ui): add Balance component styled like Revolut closes #34

### DIFF
--- a/frontend/src/components/Balance.tsx
+++ b/frontend/src/components/Balance.tsx
@@ -1,0 +1,34 @@
+type BalanceProps = {
+  balance: number;
+  accountType: string;
+  currency: string;
+}
+
+export default function Balance({ accountType, currency, balance }: BalanceProps) {
+  const formattedBalance = balance.toLocaleString("en-IE", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const [integerPart, decimalPart] = formattedBalance.split(".");
+
+  return (
+    <div className="flex flex-col text-white space-y-1 items-center">
+      
+      {/* Account type and currency */}
+      <div className="flex items-center gap-2 text-sm text-gray-400">
+        <h2 className="font-medium">{accountType}</h2>
+        <span className="text-gray-500">•</span>
+        <p className="uppercase">{currency}</p>
+      </div>
+
+      {/* Balance */}
+      <div className="flex items-baseline">
+        <span className="text-7xl font-semibold tracking-tight flex items-baseline">
+          €
+          <span>{integerPart}</span>
+          <span className="text-4xl font-normal ml-1">.{decimalPart}</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import WelcomeHeader from "../components/WelcomeHeader";
 import { useAuth } from "../context/AuthContext";
 import Container from "../components/Container";
 import CreditCard from "../components/CreditCard";
+import Balance from "../components/Balance";
 
 export default function Dashboard() {
   const {account, logOut} = useAuth();
@@ -16,10 +17,17 @@ export default function Dashboard() {
   return (
     <Container>
       <WelcomeHeader  name={account.name}/>
+
       <CreditCard 
         cardNumber={account.cardNumber}
         expiry="08/28"
         cvv="6986"
+      />
+
+      <Balance 
+        accountType="Personal" 
+        currency="EUR" 
+        balance={100.37}
       />
       <button onClick={logOut}>Log Out</button>
     </Container>


### PR DESCRIPTION
Implemented a new Balance component to display account type, currency, and amount.
- Styled to match Revolut-style balance widget
- Shows currency and balance with decimals aligned
- Integrated into Dashboard

closes #34 