### PR TITLE
docs(utils): add Javadoc comments for utility classes (CardNumberGenerator, LuhnUtils, NumberGenerator, PinGenerator)

### DIFF
--- a/backend/src/main/java/com/jamesmcdonald/backend/utils/CardNumberGenerator.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/utils/CardNumberGenerator.java
@@ -3,14 +3,22 @@ package com.jamesmcdonald.backend.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Utility class for generating valid 16-digit card numbers.
+ * <p>
+ * This class provides methods to generate card numbers that conform to standard formats,
+ * including a valid Bank Identification Number (BIN), a random customer account number,
+ * and a checksum digit calculated using the Luhn algorithm.
+ */
 public class CardNumberGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(CardNumberGenerator.class);
 
     /**
-     * Generates the 16 digit card number.
+     * Generates a valid 16-digit card number as a String.
+     * The number consists of a BIN, a customer account number, and a Luhn checksum digit.
      *
-     * @return 16-digit Card number as a String
+     * @return the 16-digit card number as a String
      */
     public static String generateCardNumber() {
         StringBuilder sb = new StringBuilder();
@@ -32,27 +40,28 @@ public class CardNumberGenerator {
     }
 
     /**
-     * Generates the BIN for the card
+     * Generates the Bank Identification Number (BIN) for the card.
      *
-     * @return The BIN number as a String
+     * @return the BIN as a String
      */
     private static String generateBin() {
         return "400000";
     }
 
     /**
-     * Generates a random customer account number
+     * Generates a random customer account number as a String.
      *
-     * @return the customer account number as a string
+     * @return the customer account number as a String
      */
     private static String generateCustomerAccountNumber() {
         return NumberGenerator.generateRandomDigitString(9);
     }
 
     /**
-     * Generates the checksum for the customer account number
+     * Calculates the checksum digit for the card number using the Luhn algorithm.
      *
-     * @return the checksum as a string
+     * @param accountIdentifierAndBin The concatenated BIN and customer account number
+     * @return the checksum digit as an integer
      */
     private static int generateChecksum(String accountIdentifierAndBin) {
         return LuhnUtils.calculateChecksum(accountIdentifierAndBin);

--- a/backend/src/main/java/com/jamesmcdonald/backend/utils/LuhnUtils.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/utils/LuhnUtils.java
@@ -5,6 +5,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
+/**
+ * A stateless utility class providing methods to validate and generate card numbers using the Luhn algorithm.
+ * <p>
+ * All methods in this class are static and thread-safe, making it suitable for use in concurrent environments.
+ * This utility is intended for use in generating or validating payment card numbers and similar identification numbers.
+ * </p>
+ */
 public class LuhnUtils {
 
     private static final Logger log = LoggerFactory.getLogger(LuhnUtils.class);

--- a/backend/src/main/java/com/jamesmcdonald/backend/utils/NumberGenerator.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/utils/NumberGenerator.java
@@ -2,6 +2,11 @@ package com.jamesmcdonald.backend.utils;
 
 import java.util.Random;
 
+/**
+ * Utility class for generating random numeric strings.
+ * This class provides methods to generate strings composed of random digits.
+ * It is intended for use in scenarios where random numeric sequences are required.
+ */
 public class NumberGenerator {
 
     /**

--- a/backend/src/main/java/com/jamesmcdonald/backend/utils/PinGenerator.java
+++ b/backend/src/main/java/com/jamesmcdonald/backend/utils/PinGenerator.java
@@ -1,7 +1,16 @@
 package com.jamesmcdonald.backend.utils;
 
+/**
+ * Utility class for generating secure 4-digit PINs for accounts.
+ */
 public class PinGenerator {
 
+    /**
+     * Generates a random 4-digit numeric PIN.
+     *
+     * @return a 4-digit PIN as a String
+     * @throws IllegalStateException if the PIN generation fails
+     */
     public static String generatePin(){
         try {
             return NumberGenerator.generateRandomDigitString(4);


### PR DESCRIPTION
Added Javadoc comments to the PinGenerator class and its generatePin method.  
- Documented the purpose of the utility as a PIN generator.  
- Explained that generatePin creates a 4-digit numeric PIN.  
- Clarified behaviour when generation fails (throws IllegalStateException).  